### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gitu/gdn_ktn_bund/security/code-scanning/2](https://github.com/gitu/gdn_ktn_bund/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly define the least privileges required for the tasks performed. The permissions should be set at the workflow level to apply to all jobs unless overridden, or at the job level for more granular control.

For this workflow:
1. The `contents: read` permission is sufficient for most steps, such as checking out code and installing dependencies.
2. The `actions: read` permission is required for downloading artifacts.
3. The `write` permissions for `pull-requests` or `issues` are not needed, as the workflow does not modify pull requests or issues.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
