### PR TITLE
ci: try to run e2e without chromium install

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -80,9 +80,12 @@ jobs:
       - name: Build application
         run: npm run build
       - name: Install playwright browsers
-        run: npx playwright install ${{ matrix.browser }} --with-deps
-      - name: Run e2e tests (${{ matrix.browser }})
         if: "${{ matrix.browser != 'chromium' }}"
+        run: npx playwright install ${{ matrix.browser }} --with-deps
+      - name: Install playwright without deps
+        if: "${{ matrix.browser == 'chromium' }}"
+        run: npx playwright install ${{ matrix.browser }}
+      - name: Run e2e tests (${{ matrix.browser }})
         run: npx playwright test --project=${{ matrix.browser }}
       - name: Upload playwright report
         if: always()


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement